### PR TITLE
[SRE-1094] fix failing build gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source "https://rubygems.org"
 
 # Used in Rakefile
 gem 'pathological' # adds '.' to $LOAD_PATH per Pathfile
-gem 'rake'
+gem 'rake', '= 11.3.0'
 gem 'test-unit'
 
 group :test do

--- a/vast.gemspec
+++ b/vast.gemspec
@@ -12,15 +12,15 @@ Gem::Specification.new do |s|
   s.email       = ['chrisgdinn@gmail.com']
   s.homepage    = 'http://github.com/chrisdinn/vast'
   s.summary     = 'A gem for working with VAST 2.0 and 3.0 documents'
+  s.description = """
+                  A gem for working with VAST 2.0 and 3.0 documents.
+                  https://www.iab.com/guidelines/digital-video-ad-serving-template-vast-2-0/
+                  """
+
   s.license     = 'MIT'
 
-  s.files       = Dir.glob('lib/**/*') + %w[LICENSE README.rdoc CHANGELOG.md]
+  s.files       = Dir.glob('lib/**/*') + %w[LICENSE README.rdoc]
   s.require_path = 'lib'
 
   s.add_dependency 'nokogiri', '~> 1.5'
-
-  s.add_development_dependency 'gem-release'
-  s.add_development_dependency 'pathological'
-  s.add_development_dependency 'rake'
-  s.add_development_dependency 'test-unit'
 end


### PR DESCRIPTION
The gem build task that only runs on master was failing. The following problems were caused by copying the open source gemspec from the latest vast version to the earlier dataxu version

- Rake version selected requires Ruby 2.0
- CHANGELOG.md doesn't exist in the dataxu fork. Remove from gemspec
- dev dependencies duplicated in gemspec and Gemfile. Remove from gemspec
- Warning: no description in vast gemspec.

FAILING MASTER:
https://ci01.devaws.dataxu.net/blue/organizations/jenkins/vast/detail/master/1/pipeline/41